### PR TITLE
Add file move and rename operations for receipts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ This is an HLedger MCP (Model Context Protocol) server implementation built with
 - **Configuration**: Configurable via CLI flags for read/write behaviour
 - **Write Tools**: `hledger_add_transaction`, `hledger_import`, `hledger_rewrite`, `hledger_remove_entry`, `hledger_replace_entry`, and `hledger_close` all write through temporary copies with optional backups
 - **Read Tools**: new commands such as `hledger_notes` extend the reporting surface while reusing query + output-format helpers
+- **File Operations**: `hledger_move_file` allows moving and renaming receipt files (PDFs and images only) when enabled with `--allow-file-operations`
 
 ### Server Structure
 
@@ -49,4 +50,5 @@ The server runs on stdio and logs startup message to stderr to avoid interfering
 
 - `--read-only`: disable the add-transaction tool (all attempts return a validation error). Default: off.
 - `--skip-backup`: skip creating `.bak` files when appending to an existing journal. Default: off.
+- `--allow-file-operations`: enable file move/rename operations for PDF and image files. Default: off (disabled for security).
 - Journal path remains the first non-flag argument; flags can be passed before or after it.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The HLedger MCP server provides comprehensive access to HLedger's financial repo
 - **Notes** - List unique transaction notes and memo fields
 - **Files** - List data files used by hledger
 
+### File Operations
+
+- **Move File** - Move or rename receipt files (PDFs and images only) for organizing documentation. Must be explicitly enabled with `--allow-file-operations` flag.
+
 ### Resource Integration
 
 - Automatically registers the primary journal and every file reported by `hledger files` as MCP resources so clients can browse and retrieve the source ledgers
@@ -119,8 +123,9 @@ You can toggle write behaviour with optional flags:
 
 - `--read-only` &mdash; disables the add-transaction tool entirely; all write attempts return an error.
 - `--skip-backup` &mdash; prevents the server from creating `.bak` files before appending to an existing journal.
+- `--allow-file-operations` &mdash; enables file move and rename operations for PDF and image files (disabled by default for safety).
 
-Flags may appear before or after the journal path. Both options default to `false`. I recommend starting with `--read-only` enabled until you get more comfortable with the tool. Below is that sample config:
+Flags may appear before or after the journal path. All options default to `false`. I recommend starting with `--read-only` enabled until you get more comfortable with the tool. Below is that sample config:
 
 ```json
 {
@@ -144,10 +149,11 @@ MCP clients that prefer configuration via environment variables can set:
 
 - `HLEDGER_READ_ONLY` &mdash; set to `true` to force read-only mode.
 - `HLEDGER_SKIP_BACKUP` &mdash; set to `true` to disable automatic `.bak` backups.
+- `HLEDGER_ALLOW_FILE_OPERATIONS` &mdash; set to `true` to enable file move/rename operations.
 - `HLEDGER_EXECUTABLE_PATH` &mdash; (Optional) absolute path to a specific `hledger` binary if it isn't on PATH; overrides auto-detection.
 - `HLEDGER_WEB_EXECUTABLE_PATH` &mdash; (Optional) absolute path to a standalone `hledger web` binary (for example `hledger-web`). When set, the MCP uses this executable instead of running `hledger web` via the primary binary.
 
-The read/write toggles mirror the CLI flags above—CLI arguments take precedence if both are provided.
+The configuration toggles mirror the CLI flags above—CLI arguments take precedence if both are provided.
 
 You can also use environment variables in place of `args` in the json config. Here is an example:
 
@@ -196,6 +202,19 @@ All write tools include a `dryRun` parameter to "try it out" before writing.
 - `hledger_web_stop` stops a selected instance by `instanceId`, `pid`, or `port`, or stops everything with `all=true`. You can optionally choose the shutdown signal (`SIGTERM` by default) and timeout.
 
 When the MCP server runs in read-only mode every web instance is forced to `allow: "view"`. Otherwise the server defaults to `allow: "add"` unless `allow: "edit"` is explicitly requested.
+
+### File operations
+
+- `hledger_move_file` allows moving and renaming receipt files (PDFs and images only) to help organize documentation. This tool is **disabled by default** and must be explicitly enabled with the `--allow-file-operations` flag for security. Supported file types include:
+  - PDF files (`.pdf`)
+  - Image files (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`, `.tiff`, `.tif`)
+
+The tool validates that:
+- Only allowed file types can be moved
+- File extensions cannot be changed during the move
+- Source files exist before attempting the operation
+- Destination directories are created if needed
+- Optional `overwrite` parameter controls whether existing destination files can be replaced
 
 ## Example Queries
 

--- a/src/tools/move-file.ts
+++ b/src/tools/move-file.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+import { promises as fs } from "fs";
+import path from "node:path";
+import type { ToolMetadata } from "../base-tool.js";
+import { BaseTool } from "../base-tool.js";
+import { ValidationError, type CommandResult } from "../types.js";
+
+// Allowed file extensions for receipts (PDF and common image formats)
+const ALLOWED_EXTENSIONS = [
+  ".pdf",
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".gif",
+  ".bmp",
+  ".webp",
+  ".tiff",
+  ".tif",
+] as const;
+
+const MoveFileInputSchema = z.object({
+  sourcePath: z
+    .string()
+    .min(1, "Source path is required")
+    .describe("The current path to the file to move or rename"),
+  destinationPath: z
+    .string()
+    .min(1, "Destination path is required")
+    .describe(
+      "The new path for the file (can be a new directory, a new filename, or both)",
+    ),
+  overwrite: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("If true, overwrite the destination file if it exists"),
+});
+
+interface MoveFileOptions {
+  allowFileOperations?: boolean;
+}
+
+export class MoveFileTool extends BaseTool<typeof MoveFileInputSchema> {
+  readonly metadata: ToolMetadata<typeof MoveFileInputSchema> = {
+    name: "hledger_move_file",
+    description:
+      "Move or rename receipt files (PDFs and images only). Useful for organizing receipts and documentation. Only enabled when --allow-file-operations flag is set.",
+    schema: MoveFileInputSchema,
+  };
+
+  private readonly allowFileOperations: boolean;
+
+  constructor(journalFilePath?: string, options: MoveFileOptions = {}) {
+    super(journalFilePath);
+    this.allowFileOperations = options.allowFileOperations ?? false;
+  }
+
+  protected async run(
+    input: z.infer<typeof MoveFileInputSchema>,
+  ): Promise<CommandResult> {
+    if (!this.allowFileOperations) {
+      throw new ValidationError(
+        "File operations are disabled. Enable with --allow-file-operations flag.",
+      );
+    }
+
+    const start = Date.now();
+
+    // Validate and normalize paths
+    const sourcePath = path.resolve(input.sourcePath);
+    const destinationPath = path.resolve(input.destinationPath);
+
+    // Validate file extension
+    const sourceExt = path.extname(sourcePath).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.includes(sourceExt as any)) {
+      throw new ValidationError(
+        `File type not allowed. Only PDF and image files can be moved. Allowed extensions: ${ALLOWED_EXTENSIONS.join(", ")}`,
+      );
+    }
+
+    // Check if source file exists
+    try {
+      const stats = await fs.stat(sourcePath);
+      if (!stats.isFile()) {
+        throw new ValidationError(
+          `Source path is not a file: ${sourcePath}`,
+        );
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new ValidationError(`Source file not found: ${sourcePath}`);
+      }
+      throw error;
+    }
+
+    // Check if destination exists
+    let destinationExists = false;
+    let destIsDirectory = false;
+    try {
+      const destStats = await fs.stat(destinationPath);
+      destinationExists = true;
+      destIsDirectory = destStats.isDirectory();
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    // Determine the final destination path
+    let finalDestPath = destinationPath;
+    if (destIsDirectory) {
+      // If destination is a directory, keep the same filename
+      finalDestPath = path.join(destinationPath, path.basename(sourcePath));
+    }
+
+    // Ensure destination directory exists
+    const destDir = path.dirname(finalDestPath);
+    try {
+      await fs.mkdir(destDir, { recursive: true });
+    } catch (error) {
+      throw new ValidationError(
+        `Failed to create destination directory: ${destDir}`,
+      );
+    }
+
+    // Check if final destination file exists
+    let finalDestExists = false;
+    try {
+      await fs.stat(finalDestPath);
+      finalDestExists = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    if (finalDestExists && !input.overwrite) {
+      throw new ValidationError(
+        `Destination file already exists: ${finalDestPath}. Use overwrite: true to replace it.`,
+      );
+    }
+
+    // Validate destination extension matches source
+    const destExt = path.extname(finalDestPath).toLowerCase();
+    if (destExt !== sourceExt) {
+      throw new ValidationError(
+        `Destination file extension (${destExt}) must match source extension (${sourceExt})`,
+      );
+    }
+
+    // Perform the move operation
+    try {
+      await fs.rename(sourcePath, finalDestPath);
+    } catch (error) {
+      // If rename fails (e.g., across file systems), try copy + delete
+      try {
+        await fs.copyFile(sourcePath, finalDestPath);
+        await fs.unlink(sourcePath);
+      } catch (fallbackError) {
+        throw new ValidationError(
+          `Failed to move file: ${(fallbackError as Error).message}`,
+        );
+      }
+    }
+
+    const duration = Date.now() - start;
+
+    return {
+      success: true,
+      stdout: JSON.stringify(
+        {
+          moved: true,
+          sourcePath,
+          destinationPath: finalDestPath,
+          overwritten: finalDestExists,
+        },
+        null,
+        2,
+      ),
+      stderr: "",
+      exitCode: 0,
+      command: `move-file ${sourcePath} -> ${finalDestPath}`,
+      duration,
+    };
+  }
+
+  protected supportsOutputFormat(): boolean {
+    return false;
+  }
+}

--- a/test/move-file-tool.test.ts
+++ b/test/move-file-tool.test.ts
@@ -1,0 +1,274 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { MoveFileTool } from "../src/tools/move-file.js";
+
+async function setupTempFileDir(): Promise<{
+  dir: string;
+  pdfPath: string;
+  jpgPath: string;
+  txtPath: string;
+}> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "hledger-move-"));
+
+  // Create test files
+  const pdfPath = path.join(dir, "receipt.pdf");
+  const jpgPath = path.join(dir, "photo.jpg");
+  const txtPath = path.join(dir, "text.txt");
+
+  await fs.writeFile(pdfPath, "fake pdf content");
+  await fs.writeFile(jpgPath, "fake jpg content");
+  await fs.writeFile(txtPath, "fake text content");
+
+  return { dir, pdfPath, jpgPath, txtPath };
+}
+
+describe("MoveFileTool", () => {
+  let tempDir: string;
+  let pdfPath: string;
+  let jpgPath: string;
+  let txtPath: string;
+
+  beforeEach(async () => {
+    const setup = await setupTempFileDir();
+    tempDir = setup.dir;
+    pdfPath = setup.pdfPath;
+    jpgPath = setup.jpgPath;
+    txtPath = setup.txtPath;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("moves a PDF file to a new location", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "receipts", "moved-receipt.pdf");
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toContain("moved-receipt.pdf");
+
+    // Verify the file was moved
+    const destExists = await fs
+      .access(destPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(destExists).toBe(true);
+
+    const sourceExists = await fs
+      .access(pdfPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(sourceExists).toBe(false);
+  });
+
+  it("renames a file in the same directory", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "renamed-receipt.pdf");
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(true);
+
+    const destExists = await fs
+      .access(destPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(destExists).toBe(true);
+
+    const sourceExists = await fs
+      .access(pdfPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(sourceExists).toBe(false);
+  });
+
+  it("moves an image file", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "images", "moved-photo.jpg");
+
+    const result = await tool.execute({
+      sourcePath: jpgPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(true);
+
+    const destExists = await fs
+      .access(destPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(destExists).toBe(true);
+  });
+
+  it("moves to a directory while keeping the original filename", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destDir = path.join(tempDir, "receipts");
+    await fs.mkdir(destDir, { recursive: true });
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destDir,
+    });
+
+    expect(result.success).toBe(true);
+
+    const expectedDest = path.join(destDir, "receipt.pdf");
+    const destExists = await fs
+      .access(expectedDest)
+      .then(() => true)
+      .catch(() => false);
+    expect(destExists).toBe(true);
+  });
+
+  it("rejects non-PDF and non-image files", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "moved-text.txt");
+
+    const result = await tool.execute({
+      sourcePath: txtPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ValidationError");
+    expect(result.message).toContain("Only PDF and image files can be moved");
+  });
+
+  it("fails when file operations are disabled", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: false });
+    const destPath = path.join(tempDir, "moved-receipt.pdf");
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ValidationError");
+    expect(result.message).toContain("File operations are disabled");
+  });
+
+  it("fails when file operations are disabled by default", async () => {
+    const tool = new MoveFileTool(); // No options - should default to disabled
+    const destPath = path.join(tempDir, "moved-receipt.pdf");
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ValidationError");
+    expect(result.message).toContain("File operations are disabled");
+  });
+
+  it("fails when source file does not exist", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const nonExistentPath = path.join(tempDir, "nonexistent.pdf");
+    const destPath = path.join(tempDir, "dest.pdf");
+
+    const result = await tool.execute({
+      sourcePath: nonExistentPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ValidationError");
+    expect(result.message).toContain("Source file not found");
+  });
+
+  it("fails when destination exists without overwrite flag", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "dest.pdf");
+    await fs.writeFile(destPath, "existing content");
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+      overwrite: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ValidationError");
+    expect(result.message).toContain("Destination file already exists");
+  });
+
+  it("overwrites destination when overwrite flag is true", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "dest.pdf");
+    await fs.writeFile(destPath, "existing content");
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+      overwrite: true,
+    });
+
+    expect(result.success).toBe(true);
+
+    const content = await fs.readFile(destPath, "utf8");
+    expect(content).toBe("fake pdf content");
+  });
+
+  it("rejects changing file extension", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "receipt.jpg"); // Trying to change .pdf to .jpg
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ValidationError");
+    expect(result.message).toContain("must match source extension");
+  });
+
+  it("supports various image formats", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const formats = ["png", "gif", "bmp", "webp", "tiff"];
+
+    for (const format of formats) {
+      const srcPath = path.join(tempDir, `image.${format}`);
+      await fs.writeFile(srcPath, "fake image");
+
+      const destPath = path.join(tempDir, `moved.${format}`);
+      const result = await tool.execute({
+        sourcePath: srcPath,
+        destinationPath: destPath,
+      });
+
+      expect(result.success).toBe(true);
+
+      // Clean up for next iteration
+      await fs.rm(destPath, { force: true });
+    }
+  });
+
+  it("creates destination directory if it doesn't exist", async () => {
+    const tool = new MoveFileTool(undefined, { allowFileOperations: true });
+    const destPath = path.join(tempDir, "nested", "dir", "structure", "file.pdf");
+
+    const result = await tool.execute({
+      sourcePath: pdfPath,
+      destinationPath: destPath,
+    });
+
+    expect(result.success).toBe(true);
+
+    const destExists = await fs
+      .access(destPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(destExists).toBe(true);
+  });
+});


### PR DESCRIPTION
This commit adds a new optional file operations feature that allows moving and renaming PDF and image files. This is particularly useful for organizing receipts and documentation.

Key features:
- New hledger_move_file tool for moving/renaming files
- Supports PDF files (.pdf) and common image formats (.jpg, .jpeg, .png, .gif, .bmp, .webp, .tiff, .tif)
- Opt-in via --allow-file-operations flag (disabled by default for security)
- Can be configured via CLI flag or HLEDGER_ALLOW_FILE_OPERATIONS env var
- Validates file types, prevents extension changes, creates directories as needed
- Optional overwrite parameter for replacing existing files
- Comprehensive test suite with 13 tests covering all scenarios

Implementation:
- Added src/tools/move-file.ts with MoveFileTool class
- Updated src/index.ts to parse --allow-file-operations flag and register tool
- Added test/move-file-tool.test.ts with full test coverage
- Updated README.md and CLAUDE.md documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)